### PR TITLE
get_commit_info: return JSON string

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -1,17 +1,13 @@
 const execSync = require("child_process").execSync;
+const formatStr = '{"hash":"%h","author":"%an","message":"%s"}';
 
 module.exports = {
   // TODO
   // - change shell's current directory to where the user's project is
+  // - get branch from commit hash
   get_commit_info: function () {
-    const output = execSync("git log --oneline", { encoding: "utf8" })
-      .split("\n")
-      .filter((s) => s.length > 0);
-    return output.map(function (line) {
-      const sepIndex = line.indexOf(" ");
-      const commitHash = line.substring(0, sepIndex);
-      const commitMsg = line.substring(sepIndex + 1, line.length);
-      return { commitHash: commitHash, commitMsg: commitMsg };
+    return execSync(`git log --format='format:${formatStr}'`, {
+      encoding: "utf8",
     });
   },
 };


### PR DESCRIPTION
Use --format option with git log for better control over output, so we can have a JSON output to be parsed later.