### PR TITLE
Fix CI error on dependecy packages installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
-          
+
       - name: Install dependencies
         run: npm install
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "npm"
-
-      - name: Install required package libraries
-        run: sudo apt-get install -y libkrb5-dev
-
+          
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
## Why these changes?

Once NodeGit is not used anymore, we can remove this old dependency packages installation from CI, which is now giving 404 error on Ubuntu package manager mirrors.