### PR TITLE
Fix merge rendering

### DIFF
--- a/src/git.js
+++ b/src/git.js
@@ -80,12 +80,26 @@ class Repository {
     )
       .split("\n")
       .filter((s) => s.length != 0);
+
     if (numberOfParents > 1 && commitBranches.includes("master")) {
       return "master";
     } else if (numberOfParents > 1 && commitBranches.includes("main")) {
       return "main";
     } else {
-      return commitBranches[0];
+      const graphBranches = this.shell_exec(
+        `git log --graph --format='format:%h' --branches | grep "${commitHash}"`,
+      )
+        .trim()
+        .split(" ")
+        .filter((s) => s.length != 0);
+
+      const firstStarIndex = graphBranches.indexOf("*");
+
+      if (firstStarIndex == 0) {
+        return commitBranches.pop();
+      } else {
+        return commitBranches[0];
+      }
     }
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -124,12 +124,6 @@ app.on("window-all-closed", () => {
   if (process.platform !== "darwin") app.quit();
 });
 
-app.on("activate", () => {
-  if (textInputWindow === null) {
-    createTextInputWindow();
-  }
-});
-
 const env = process.env.NODE_ENV || "development";
 if (env === "development") {
   try {


### PR DESCRIPTION
## Hotfix

Merge rendering was choosing only last branch. In cases of forks, this is a bug, because last branches is most recently created branches, but is not where commit came from. We solve this case to current branch cases: if star is in first position on CLI log graph, so the actual branch need to be choose for commit branch.